### PR TITLE
Update to Java Version to 21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'temurin'
           cache: maven
       - name: Build with Maven

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.3</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>de.orciument</groupId>
@@ -16,7 +16,7 @@
     <name>JavaTwitchBot</name>
     <description>JavaTwitchBot</description>
     <properties>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
     </properties>
 
     <dependencies>
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-jdbc</artifactId>
-            <version>5.3.23</version>
+            <version>6.0.11</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
### Why change to java 21?
With our current threading model, we could really benefit from virtual threats. 
There is a Thread created every time an event is dispatched, this could be mitigated by using a Threadpool, but this would introduce extra complexity, compared to using virtual Threads. The amount of work we do is also highly variable, so there could be benefits in not always holding on to a bunch of unused Threads. 
 
I would also suggest upgrading sooner rather than later, because even if we don't use any of the new language features, it will be harder to upgrade in the future in case we need some of these features