### PR TITLE
removed because it was not needed

### DIFF
--- a/src/main/talium/TwitchBot.java
+++ b/src/main/talium/TwitchBot.java
@@ -34,9 +34,7 @@ public class TwitchBot {
         System.out.println("DDD-HH:mm:ss.SSS |LEVEL| [THREAD]        LOGGER (Source Class)               - MSG");
         System.out.println("-----------------|-----|-[-------------]---------------------------------------------------------------------------------------------------------------------------------------------");
         InputManager.startAllInputs();
-        new CommandProcessor();
         HealthManager.subscribeNextChange(status -> time.close(), InputStatus.HEALTHY);
-//        CommandProcessor.generateJunkCommands();
     }
 
     @PreDestroy


### PR DESCRIPTION
Result: 
no it is not needed, static vars are initialised when the class is loaded, so when something is interacting with the class for the first time, like a method call. Then the class is loaded, and all static fields are initialised. 
If we need to have more complex logic for the initialisation of static fields, we can use static initializer:  
```java
static final String test;

static {
  // some calc
  test = "testString";
}
```
(and it even counts as final that way! :D)
closes #33 
